### PR TITLE
Fixes:

### DIFF
--- a/Graph.cpp
+++ b/Graph.cpp
@@ -79,5 +79,6 @@ string Graph::toString()
 		}
 	}
 	result += "]";
+	result += "}";
 	return result;
 }

--- a/GraphController.cpp
+++ b/GraphController.cpp
@@ -29,8 +29,18 @@ void GraphController::handleGet(http_request message)
     {
         if (path[0] == to_string_t("graph")) 
         {
+            if (path.size() < 2)
+            {
+                message.reply(status_codes::BadRequest);
+                return;
+            }
             int id = stoi(path[1]);
             auto graph = graphService->getGraph(id);
+            if (graph == nullptr)
+            {
+                message.reply(status_codes::NotFound);
+                return;
+            }
             json::value graphJson;
             graphJson[to_string_t("graph")] = json::value::string(to_string_t(graph->toString()));
             message.reply(status_codes::OK, graphJson);
@@ -38,10 +48,20 @@ void GraphController::handleGet(http_request message)
         }
         else if(path[0] == to_string_t("edmonds-karp"))
         {
+            if (path.size() < 4)
+            {
+                message.reply(status_codes::BadRequest);
+                return;
+            }
             int id = stoi(path[1]);
             int source = stoi(path[2]);
             int destination = stoi(path[3]);
             auto graph = graphService->getGraph(id);
+            if (graph == nullptr)
+            {
+                message.reply(status_codes::NotFound);
+                return;
+            }
             auto result = edmondsKarpService->calculateMaxFlow(graph, source, destination);
             json::value resultJson;
             resultJson[to_string_t("result")] = json::value::number(result);

--- a/GraphRepository.cpp
+++ b/GraphRepository.cpp
@@ -40,5 +40,5 @@ GraphRepository::~GraphRepository()
 
 Graph* GraphRepository::getGraph(int id)
 {
-	return graphs[id]->clone();
+	return (id < 0 || id >= size || graphs[id] == nullptr) ? nullptr : graphs[id]->clone();
 }

--- a/KeyboardInterruptHandler.cpp
+++ b/KeyboardInterruptHandler.cpp
@@ -52,8 +52,8 @@ int KeyboardInterruptHandler::handleKeyboardInterrupt()
         break;
     default:
         cout << endl << "Wait error" << endl;
-        return 0;
     }
+    return 0;
 #endif
 #ifdef linux
     struct sigaction sigIntHandler;


### PR DESCRIPTION
1. KeyboardInterruptHandler.cpp - KeyboardInterruptHandler::handleKeyboardInterrupt - fixed return statement
2. Graph.cpp - Graph::toString - fixed returned string (added "}" sign at the end)
3. GraphRepository.cpp, GraphController.cpp - bad arguments (incorrect quantity, incorrect numbers) handled

Signed-off-by: Mateusz <mateusz.niescier@onet.pl>